### PR TITLE
Use old "Function.prototype.apply" method instead of rest arguments.

### DIFF
--- a/host.js
+++ b/host.js
@@ -67,7 +67,7 @@ function observe (msg, push, done) {
     if (msg.env) {
       msg.env.forEach(n => process.env.PATH += path.delimiter + n);
     }
-    let p = Array.isArray(msg.command) ? path.join(...msg.command) : msg.command;
+    let p = Array.isArray(msg.command) ? path.join.apply(path, msg.command) : msg.command;
     let sp = spawn(p, msg.arguments || [], Object.assign({env: process.env}, msg.properties));
 
     if (msg.kill) {
@@ -150,7 +150,7 @@ function observe (msg, push, done) {
     if (msg.env) {
       msg.env.forEach(n => process.env.PATH += path.delimiter + n);
     }
-    let p = Array.isArray(msg.command) ? path.join(...msg.command) : msg.command;
+    let p = Array.isArray(msg.command) ? path.join.apply(path, msg.command) : msg.command;
     let sp = spawn(p, msg.arguments || [], Object.assign({
       env: process.env,
       detached: true


### PR DESCRIPTION
On Ubuntu 16.04LTS (available until April 2021), `apt install node` installs node v4.2.6 - it is too old thus it doesn't support the rest arguments syntax (`...`) and just reports syntax error.

There are some methods to install newer versions of node to Ubuntu 16.04LTS, however, I think it is not an LTS way because unexpected version of node possibly introduce problems to other depending software.