### PR TITLE
Fix "cmd is unknown" errors on version check

### DIFF
--- a/host.js
+++ b/host.js
@@ -49,7 +49,7 @@ function observe(msg, push, done) {
     });
     done();
   }
-  if (msg.cmd === 'spec') {
+  else if (msg.cmd === 'spec') {
     push({
       version: config.version,
       env: process.env,


### PR DESCRIPTION
The execution continued after version check was made, ending up in "cmd is unknown".