### PR TITLE
Fix #118: Cannot find module '${HOME}/host.js'

### DIFF
--- a/linux/app/install.js
+++ b/linux/app/install.js
@@ -86,7 +86,7 @@ function application() {
         return reject(e);
       }
       const isNode = process.argv.filter(a => a === '--add_node').length === 0;
-      const run = `#!/usr/bin/env bash\n${isNode ? process.argv[0] : './node'} host.js`;
+      const run = `#!/usr/bin/env bash\n${isNode ? process.argv[0] : './node'} $(dirname "$0")/host.js`;
       fs.writeFile(path.join(dir, 'run.sh'), run, e => {
         if (e) {
           return reject(e);


### PR DESCRIPTION
It appears that Firefox starts the native client from `$HOME` as the working directory. That leads to the script resolving the relative path host.js as `$HOME/host.js`.

This fix prefixes the `host.js` filename with the directory of the run.sh file. Now it works regardless of the working directory and regardless of the directory in which `run.sh` and the JavaScript files are located (as long as they are in the same location).

Fix: andy-portmen/native-client#118