### PR TITLE
Add install support for Ungoogled Chromium flatpak

### DIFF
--- a/linux/app/install.js
+++ b/linux/app/install.js
@@ -199,6 +199,11 @@ const FLATPAK_BROWSERS = {
     type: 'chrome',
     name: 'Vivaldi (Flatpak)'
   },
+  'io.github.ungoogled_software.ungoogled_chromium': {
+    path: 'config/chromium/NativeMessagingHosts',
+    type: 'chrome',
+    name: 'Ungoogled Chromium (Flatpak)'
+  },
   // Firefox-based browsers
   'org.mozilla.firefox': {
     path: '.mozilla/native-messaging-hosts',


### PR DESCRIPTION
I'm using [Ungoogled Chromium](https://github.com/ungoogled-software/ungoogled-chromium)'s flatpak distribution to run my PWAs with Firefox as main browser and wanted to try this extension to make PWA links open in Firefox.

I noticed that the latest flatpak support only includes certain browsers, so I added mine.

### Side note:

After applying this PR's change, I was getting "Native host exited" error. Then I found

> Hint: --host only works when the Flatpak is allowed to talk to org.freedesktop.Flatpak

in the browser's logs which lead me to run `sudo flatpak override io.github.ungoogled_software.ungoogled_chromium --talk-name=org.freedesktop.Flatpak` which made it work. I guess other browsers have this permission by default...?